### PR TITLE
fixing regressed change - tab should move to next dialog, see https:/…

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1204,7 +1204,7 @@ export default class Select extends Component<Props, State> {
           return;
         }
         this.selectOption(focusedOption);
-        break;
+        return;
       case 'Enter':
         if (event.keyCode === 229) {
           // ignore the keydown event from an Input Method Editor(IME)


### PR DESCRIPTION
Copy of #3930

> #708
>
>Conventional UX is that a tab switches to a new input. I don't know if this was reverted intentionally, or by accident, but this fixes the problem.