### PR TITLE
Fix error when touches is not set

### DIFF
--- a/.changeset/quiet-parrots-wonder.md
+++ b/.changeset/quiet-parrots-wonder.md
@@ -1,0 +1,5 @@
+---
+'react-select-reborn': patch
+---
+
+Fix touch event error in IE11

--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1026,7 +1026,7 @@ export default class Select extends Component<Props, State> {
     }
   }
   onTouchStart = ({ touches }: TouchEvent) => {
-    const touch = touches.item(0);
+    const touch = touches && touches.item(0);
     if (!touch) {
       return;
     }
@@ -1036,7 +1036,7 @@ export default class Select extends Component<Props, State> {
     this.userIsDragging = false;
   };
   onTouchMove = ({ touches }: TouchEvent) => {
-    const touch = touches.item(0);
+    const touch = touches && touches.item(0);
     if (!touch) {
       return;
     }


### PR DESCRIPTION
Copy of JedWatson#3904 by @andreme

>I get errors from IE 11 where the touches prop from touch events does not seem to be set.